### PR TITLE
fixed parser problem with using xxx;

### DIFF
--- a/edition/parsing/file_parser.py
+++ b/edition/parsing/file_parser.py
@@ -199,6 +199,9 @@ class FileParser(object):
             declarations.add(CPPItem(CPPItem.STRUCT, name, scope))
             return
 
+        if 'using' in tokens:
+            return
+
         if 'extern' in tokens and statement[1] is not None:  # for extern "C" { constructs
             self.recursive_parser(statement[1], scope, declarations, definitions)
 

--- a/test/edition/parsing/cpp/cpp_parser_test.py
+++ b/test/edition/parsing/cpp/cpp_parser_test.py
@@ -1,7 +1,6 @@
 import unittest
 from biicode.common.edition.parsing.cpp.drl_parser import DRLCPPParser
-from biicode.common.model.blob import Blob
-from nose_parameterized import parameterized #@UnresolvedImport
+from nose_parameterized import parameterized
 
 
 class CPPParserTest(unittest.TestCase):
@@ -42,6 +41,7 @@ int main() {
 }
 
 """
+
     @parameterized.expand([
         (int_main, ),
         (void_main, ),
@@ -72,5 +72,3 @@ const word32 CAST::S[8][256] = {
 """
         parser = DRLCPPParser()
         parser.parse(text)
-        pass
-        #self.assertTrue(parser.)

--- a/test/edition/parsing/cpp/drl_parser_test.py
+++ b/test/edition/parsing/cpp/drl_parser_test.py
@@ -276,6 +276,13 @@ int c = 8;
         self.assertIn(CPPDeclaration('../include/gtest/internal/gtest-port.h'),
                       parser.explicit_declarations)
 
+    def test_using_no_definition(self):
+        code = "using blobstore::onblocks::utils::ceilDivision;"
+        parser = DRLCPPParser()
+        parser.parse(code)
+        expected = set()
+        self.assertItemsEqual(expected, parser.definitions)
+
     def test_scope_in_const_definition(self):
         code = """
 #include "cryptopp/cryptopp/pch.h"

--- a/test/edition/processors/cpp_implementation_test.py
+++ b/test/edition/processors/cpp_implementation_test.py
@@ -135,6 +135,21 @@ LexicalHandler::~LexicalHandler()
 } } // namespace Poco::XML
 """
 
+using_ns_body = """using blobstore::onblocks::utils::ceilDivision;"""
+
+using_ns_header = """namespace blobstore {
+namespace onblocks {
+namespace utils {
+
+uint32_t intPow(uint32_t base, uint32_t exponent);
+uint32_t ceilDivision(uint32_t dividend, uint32_t divisor);
+uint32_t maxZeroSubtraction(uint32_t minuend, uint32_t subtrahend);
+
+}
+}
+}
+"""
+
 
 class CPPImplementationProcessorTest(BiiTestCase):
     '''tests de CPPImplementation processor from 2 sources, from some source files in tests folder
@@ -241,6 +256,7 @@ class CPPImplementationProcessorTest(BiiTestCase):
         ('', ''),
         (crypto_header, ''),
         ('', basic_class_body),
+        (using_ns_header, using_ns_body)
     ])
     def test_negative(self, header, source):
         '''some basic negative tests, from snippets of code'''


### PR DESCRIPTION
An incorrect C++ implicit dependency of implementation was detected when using:

using ns::ns2::function; 

Detected as variable definition in parser.

Closes #1 
