### PR TITLE
do not serialize dependencies blobs to local DB

### DIFF
--- a/deps/block_version_graph.py
+++ b/deps/block_version_graph.py
@@ -1,5 +1,4 @@
-from biicode.common.deps.directed_graph import DirectedGraph, DirectedGraphDeserializer
-from biicode.common.model.symbolic.block_version import BlockVersion
+from biicode.common.deps.directed_graph import DirectedGraph
 from collections import defaultdict
 
 
@@ -14,11 +13,6 @@ class BlockVersionGraph(DirectedGraph):
         for node in self.nodes:
             result[node.block_name].add(node)
         return result
-
-    @staticmethod
-    def deserialize(data):
-        deserializer = DirectedGraphDeserializer(BlockVersion, cls=BlockVersionGraph)
-        return deserializer.deserialize(data)
 
     def collision(self, other):
         '''computation of the minimum graph that contains possible sources of incompatibilities

--- a/deps/closure.py
+++ b/deps/closure.py
@@ -1,12 +1,4 @@
 from collections import namedtuple
-from biicode.common.utils.serializer import Serializer, ListDeserializer
-from biicode.common.model.brl.block_cell_name import BlockCellName
-from biicode.common.model.resource import ResourceDeserializer
-from biicode.common.model.symbolic.block_version import BlockVersion
-from biicode.common.exception import BiiSerializationException
-from biicode.common.model.cells import CellDeserializer
-from biicode.common.model.content import ContentDeserializer
-from biicode.common.model.id import ID
 from biicode.common.edition.block_holder import BIICODE_FILE
 
 
@@ -27,28 +19,3 @@ class Closure(dict):
             biiout.warn('Using version "%s" while you fix it' % (old_item.version, ))
         else:
             self[resource.name] = ClosureItem(resource, version)
-
-    SERIAL_NAMES = 'names'
-    SERIAL_RESOURCES = 'resources'
-    SERIAL_VERSIONS = 'versions'
-
-    def serialize(self):
-        if self:
-            resources, versions = zip(*self.values())
-        else:
-            resources, versions = [], []
-        ser = Serializer().build((Closure.SERIAL_NAMES, self.keys()),
-                                 (Closure.SERIAL_RESOURCES, resources),
-                                 (Closure.SERIAL_VERSIONS, versions))
-        return ser
-
-    @staticmethod
-    def deserialize(data):
-        try:
-            names = ListDeserializer(BlockCellName).deserialize(data[Closure.SERIAL_NAMES])
-            d = ResourceDeserializer(CellDeserializer(ID), ContentDeserializer(ID))
-            resources = ListDeserializer(d).deserialize(data[Closure.SERIAL_RESOURCES])
-            versions = ListDeserializer(BlockVersion).deserialize(data[Closure.SERIAL_VERSIONS])
-            return Closure(dict(zip(names, zip(resources, versions))))
-        except Exception as e:
-            raise BiiSerializationException(e)

--- a/deps/directed_graph.py
+++ b/deps/directed_graph.py
@@ -1,42 +1,11 @@
 from pygraph.classes.digraph import digraph
 from pygraph.algorithms.sorting import topological_sorting
 from pygraph.algorithms.cycles import find_cycle
-from biicode.common.utils.serializer import Serializer, SetDeserializer, serialize
 from collections import namedtuple
 
 
 class Edge(namedtuple('Edge', ['source', 'target', 'value'])):
-    def serialize(self):
-        if self.value:
-            return (serialize(self.source), serialize(self.target), serialize(self.value))
-        else:
-            return (serialize(self.source), serialize(self.target))
-
-
-class EdgeDeserializer(object):
-    def __init__(self, node_class, edge_class):
-        self.edge_class = edge_class
-        self.node_class = node_class
-
-    def deserialize(self, data):
-        if data is None:
-            return None
-
-        if callable(getattr(self.node_class, "deserialize", None)):
-            source = self.node_class.deserialize(data[0])
-            target = self.node_class.deserialize(data[1])
-        else:
-            source = self.node_class(data[0])
-            target = self.node_class(data[1])
-
-        if self.edge_class and len(data) > 2:
-            if callable(getattr(self.edge_class, "deserialize", None)):
-                value = self.edge_class.deserialize(data[2])
-            else:
-                value = data[2]
-        else:
-            value = None
-        return Edge(source, target, value)
+    pass
 
 
 class DirectedGraph(object):
@@ -207,29 +176,3 @@ class DirectedGraph(object):
             for n in add_edges_nodes:
                 result.add_edge(n, elem)
         return result
-
-    SERIAL_NODES = "n"
-    SERIAL_EDGES = "e"
-
-    def serialize(self):
-        res = Serializer().build(
-            (DirectedGraph.SERIAL_NODES, self.nodes),
-            (DirectedGraph.SERIAL_EDGES, self.edges),
-        )
-        return res
-
-
-class DirectedGraphDeserializer(object):
-    def __init__(self, node_class, edge_class=None, cls=DirectedGraph):
-        self.cls = cls
-        self.node_class = node_class
-        self.edge_class = edge_class
-
-    def deserialize(self, data):
-        if data is None:
-            return None
-        g = self.cls()
-        g.nodes = SetDeserializer(self.node_class).deserialize(data[DirectedGraph.SERIAL_NODES])
-        items_deserializer = EdgeDeserializer(self.node_class, self.edge_class)
-        g.edges = SetDeserializer(items_deserializer).deserialize(data[DirectedGraph.SERIAL_EDGES])
-        return g

--- a/edition/hive.py
+++ b/edition/hive.py
@@ -2,13 +2,11 @@ from biicode.common.model.brl.block_cell_name import BlockCellName
 from biicode.common.utils.serializer import Serializer, SetDeserializer
 from biicode.common.exception import BiiSerializationException
 from biicode.common.settings.settings import Settings
-from biicode.common.edition.hive_dependencies import HiveDependencies
 
 
 class Hive(object):
 
     def __init__(self):
-        self.hive_dependencies = HiveDependencies()
         self.settings = None
         self._cells = set()  # of BlockCellName
 
@@ -32,11 +30,9 @@ class Hive(object):
 
     SERIAL_CELLS_KEY = 'r'
     SERIAL_SETTINGS = 'd'
-    SERIAL_HIVE_DEPENDENCIES = 'deps'
 
     def serialize(self):
         return Serializer().build(
-            (Hive.SERIAL_HIVE_DEPENDENCIES, self.hive_dependencies),
             (Hive.SERIAL_CELLS_KEY, self._cells),
             (Hive.SERIAL_SETTINGS, self.settings)
         )
@@ -45,8 +41,6 @@ class Hive(object):
     def deserialize(data):
         try:
             hive = Hive()
-            hive.hive_dependencies = HiveDependencies.deserialize(
-                                                            data[Hive.SERIAL_HIVE_DEPENDENCIES])
             hive._cells = SetDeserializer(BlockCellName).deserialize(data[Hive.SERIAL_CELLS_KEY])
             hive.settings = Settings.deserialize(data[Hive.SERIAL_SETTINGS])
             return hive

--- a/edition/hive_dependencies.py
+++ b/edition/hive_dependencies.py
@@ -1,8 +1,4 @@
-from biicode.common.utils.serializer import Serializer
-from biicode.common.exception import BiiSerializationException
 from biicode.common.deps.block_version_graph import BlockVersionGraph
-from biicode.common.model.symbolic.block_version_table import BlockVersionTable
-from biicode.common.model.symbolic.reference import References
 from biicode.common.deps.closure import Closure
 
 
@@ -11,9 +7,7 @@ class HiveDependencies(object):
     current graph, as well as the closure
     """
     def __init__(self):
-        self.dep_table = None  # BlockVersionTable()
         self.references = None  # References()
-        # TODO: The whole closure is being serialized. Check performance, improve
         self.closure = Closure()  # {BlockCellName: Resource}
         self.src_graph = BlockVersionGraph()  # BlockVersionGraph
         self.dep_graph = BlockVersionGraph()  # BlockVersionGraph
@@ -21,31 +15,3 @@ class HiveDependencies(object):
     @property
     def version_graph(self):
         return self.src_graph + self.dep_graph
-
-    SERIAL_DEP_TABLE = 'd'
-    SERIAL_REFERENCES = 'r'
-    SERIAL_CLOSURE = 'c'
-    SERIAL_SRC_GRAPH = 'sg'
-    SERIAL_DEP_GRAPH = 'dg'
-
-    def serialize(self):
-        return Serializer().build(
-            (HiveDependencies.SERIAL_DEP_TABLE, self.dep_table),
-            (HiveDependencies.SERIAL_REFERENCES, self.references),
-            (HiveDependencies.SERIAL_CLOSURE, self.closure),
-            (HiveDependencies.SERIAL_SRC_GRAPH, self.src_graph),
-            (HiveDependencies.SERIAL_DEP_GRAPH, self.dep_graph),
-        )
-
-    @staticmethod
-    def deserialize(data):
-        try:
-            res = HiveDependencies()
-            res.dep_table = BlockVersionTable.deserialize(data[HiveDependencies.SERIAL_DEP_TABLE])
-            res.references = References.deserialize(data[HiveDependencies.SERIAL_REFERENCES])
-            res.closure = Closure.deserialize(data[HiveDependencies.SERIAL_CLOSURE])
-            res.src_graph = BlockVersionGraph.deserialize(data[HiveDependencies.SERIAL_SRC_GRAPH])
-            res.dep_graph = BlockVersionGraph.deserialize(data[HiveDependencies.SERIAL_DEP_GRAPH])
-            return res
-        except Exception as e:
-            raise BiiSerializationException(e)

--- a/edition/hive_holder.py
+++ b/edition/hive_holder.py
@@ -10,6 +10,7 @@ from biicode.common.model.symbolic.block_version import BlockVersion
 class HiveHolder(object):
 
     def __init__(self, hive, dict_cells, dict_contents):
+        self.hive_dependencies = None  # MUST BE ALWAYS BE ASSIGNED before usage
         self.hive = hive
         resource_dict = defaultdict(list)
         for block_cell_name, cell in dict_cells.iteritems():

--- a/edition/hive_manager.py
+++ b/edition/hive_manager.py
@@ -1,6 +1,5 @@
 from biicode.common.model.brl.block_name import BlockName
-from biicode.common.edition.hiveprocessor import (blocks_process, deps_process,
-                                                  compute_src_graph, compute_common_table)
+from biicode.common.edition.hiveprocessor import blocks_process, deps_process
 from biicode.common.edition.processors.processor_changes import ProcessorChanges
 from biicode.common.edition.checkin import checkin_files, checkin_block_files
 from biicode.common.exception import BiiException, UpToDatePublishException,\
@@ -89,7 +88,7 @@ class HiveManager(object):
         return version
 
     def _publish_all(self, tag, msg, versiontag):
-        src_graph = self.hive_holder.hive.hive_dependencies.src_graph
+        src_graph = self.hive_holder.hive_dependencies.src_graph
         levels = src_graph.get_levels()
         versions = []
         for level in levels:
@@ -115,8 +114,7 @@ class HiveManager(object):
 
     @property
     def closure(self):
-        hive = self.hive
-        return hive.hive_dependencies.closure
+        return self.hive_holder.hive_dependencies.closure
 
     def update(self, block_name=None, time=None):
         """ a block is outdated, because someone has published from another location,

--- a/edition/hiveprocessor.py
+++ b/edition/hiveprocessor.py
@@ -8,6 +8,7 @@ from biicode.common.exception import BiiException, NotFoundException
 from biicode.common.deps.block_version_graph import BlockVersionGraph
 from biicode.common.deps.closure_builder import build_closure
 from biicode.common.model.symbolic.block_version_table import BlockVersionTable
+from biicode.common.edition.hive_dependencies import HiveDependencies
 
 
 def blocks_process(hive_holder, processor_changes, biiout):
@@ -44,11 +45,12 @@ def deps_process(biiapi, hive_holder, processor_changes, biiout, settings=None):
     src_graph, references = compute_src_graph(hive_holder, common_table)
     dep_graph, closure, overwrites = build_closure(biiapi, references, common_table, settings,
                                                    biiout)
-    hive_dependencies = hive_holder.hive.hive_dependencies
+    hive_dependencies = HiveDependencies()
     hive_dependencies.src_graph = src_graph  # BlockVersionGraph
     hive_dependencies.dep_graph = dep_graph  # BlockVersionGraph
     hive_dependencies.closure = closure
     hive_dependencies.references = references
+    hive_holder.hive_dependencies = hive_dependencies
 
     real_graph = src_graph + dep_graph
     real_graph.sanitize(biiout)

--- a/edition/open_close.py
+++ b/edition/open_close.py
@@ -6,7 +6,7 @@ from biicode.common.model.symbolic.block_version import BlockVersion
 
 
 def select_version(hive_holder, biiapi, biiout, block_name, track, time, version_tag):
-    dependencies = hive_holder.hive.hive_dependencies.dep_graph.nodes
+    dependencies = hive_holder.hive_dependencies.dep_graph.nodes
     dep_block_versions = {x.block_name: x for x in dependencies}
     existing_version = dep_block_versions.get(block_name)
     if existing_version:

--- a/publish/publish_manager.py
+++ b/publish/publish_manager.py
@@ -98,7 +98,7 @@ def _check_input(hive_holder, block_name):
     if block_name not in hive_holder.blocks:
         raise PublishException('Block "%s" does not exist in your project' % block_name)
 
-    hive_dependencies = hive_holder.hive.hive_dependencies
+    hive_dependencies = hive_holder.hive_dependencies
     gr = hive_dependencies.version_graph
     cycles = gr.get_cycles()
     if cycles:

--- a/test/model/directed_graph_test.py
+++ b/test/model/directed_graph_test.py
@@ -1,6 +1,5 @@
 import unittest
-
-from biicode.common.deps.directed_graph import DirectedGraph, DirectedGraphDeserializer
+from biicode.common.deps.directed_graph import DirectedGraph
 from biicode.common.model.brl.block_name import BlockName
 
 
@@ -136,23 +135,3 @@ class DirectedGraphTest(unittest.TestCase):
         # Inverse closure
         self.assertEqual({31}, gr.inverse_reachable_subgraph(31).nodes)
         self.assertEqual({11, 22, 31, 1}, gr.inverse_reachable_subgraph(1).nodes)
-
-    def test_serialize(self):
-        gr = DirectedGraph()
-        gr.add_nodes([1, 2, 3, 11, 12, 21, 22, 23, 31])
-
-        gr.add_edge(11, 1)
-        gr.add_edge(12, 2)
-        gr.add_edge(21, 12)
-        gr.add_edge(22, 11)
-        gr.add_edge(31, 21)
-        gr.add_edge(31, 22)
-        gr.add_edge(31, 23)
-
-        s = gr.serialize()
-        gr2 = DirectedGraphDeserializer(int).deserialize(s)
-        self.assertEquals(gr, gr2)
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()


### PR DESCRIPTION
This PR removes the serialization to local project DB of HiveDependencies() object, which was done just for legacy reasons.
It is a step forward decoupling the storage backend for biicode (VCS)

**It improves 30% of speed** in processing when depending on large number of files.