### PR TITLE
Autocrlf in settings. Closes biicode/biicode#16

### DIFF
--- a/edition/checkin.py
+++ b/edition/checkin.py
@@ -1,100 +1,114 @@
-from biicode.common.edition.type_filter import TypeFilter
-from biicode.common.model.blob import Blob
 from biicode.common.utils.bii_logging import logger
 from biicode.common.edition.block_holder import BlockHolder
-from biicode.common.model.resource import Resource
 from biicode.common.model.cells import SimpleCell
 from biicode.common.model.content import Content
 from biicode.common.edition import changevalidator
 from biicode.common.edition.processors.processor_changes import ProcessorChanges
 from biicode.common.model.brl.block_name import BlockName
+from biicode.common.settings.settings import Settings
+from biicode.common.model.resource import Resource
+from biicode.common.edition.type_filter import TypeFilter
+from biicode.common.model.blob import Blob
 
 
-def checkin_block_files(hive_holder, block_name, files, processor_changes, biiout):
-    '''
-    Params:
-        hive_holder: HiveHolder
-        block_name: BlockName
-        files: {cell_name: content}
-        processor_changes: ProcessorChanges
-        biiout: biiout
-    '''
-    block_name = BlockName(block_name)
-    types_blobs = obtain_types_blobs(files)  # {cell_name: (TYPE, Content/CellType/None)}
-    # FIXME: What happens if merge result is larger than individual files, reject???
-    changevalidator.remove_large_cells(types_blobs, biiout)
-    try:
-        block_holder = hive_holder[block_name]
-    except KeyError:
-        block_holder = BlockHolder(block_name, [])
-        hive_holder.add_holder(block_holder)
+class CheckinManager(object):
 
-    for cell_name, (biitype, blob) in types_blobs.iteritems():
-        block_cell_name = block_name + cell_name
-        cell = SimpleCell(block_cell_name, biitype)
+    def __init__(self, hive_holder, settings, biiout):
+        '''
+        Params:
+            hive_holder: HiveHolder
+            settings: Settings
+            biiout: biiout
+        '''
+        self.hive_holder = hive_holder
+        self.settings = settings or Settings()
+        self.biiout = biiout
+
+    def checkin_files(self, files):
+        '''
+        Params:
+            files: dict{BlockCellName: Item (str or bytes loaded from file)}
+        Returns: ProcessorChanges
+        '''
+        logger.debug("----------- checkin  ---------------")
+        hive = self.hive_holder.hive
+        hive.settings = self.settings
+
+        processor_changes = ProcessorChanges()
+        if files is None:
+            return processor_changes
+
+        block_files = {}
+        for block_cell_name, filecontent in files.iteritems():
+            block_files.setdefault(block_cell_name.block_name,
+                                   {})[block_cell_name.cell_name] = filecontent
+
+        for block_name, files in block_files.iteritems():
+            self.checkin_block_files(block_name, files, processor_changes)
+
+        for block_holder in self.hive_holder.block_holders:
+            if block_holder.block_name not in block_files:
+                processor_changes.deleted.update(block_holder.block_cell_names)
+                self.hive_holder.add_holder(BlockHolder(block_holder.block_name, []))
+
+        self.hive_holder.delete_empty_blocks()
+        hive.update(processor_changes)
+
+        # Raises if max is overtaken
+        changevalidator.check_hive_num_cells(hive)
+        return processor_changes
+
+    def checkin_block_files(self, block_name, files, processor_changes):
+        '''
+        Params:
+            block_name: BlockName
+            files: {cell_name: content}
+            processor_changes: ProcessorChanges
+        '''
+        block_name = BlockName(block_name)
+        normalize = self.settings.user.get("autocrlf", True)
+        if not normalize:
+            self.biiout.info("Skipping file normalizing")
+
+        types_blobs = obtain_types_blobs(files, normalize)  # {cell_name: (TYPE, Content/CellType/None)}
+        # FIXME: What happens if merge result is larger than individual files, reject???
+        changevalidator.remove_large_cells(types_blobs, self.biiout)
         try:
-            resource = block_holder[cell_name]
+            block_holder = self.hive_holder[block_name]
         except KeyError:
-            content = Content(block_cell_name, load=blob)
-            processor_changes.upsert(block_cell_name, content)
-        else:
-            content = resource.content
-            if content is None or blob != content.load:
+            block_holder = BlockHolder(block_name, [])
+            self.hive_holder.add_holder(block_holder)
+
+        for cell_name, (biitype, blob) in types_blobs.iteritems():
+            block_cell_name = block_name + cell_name
+            cell = SimpleCell(block_cell_name, biitype)
+            try:
+                resource = block_holder[cell_name]
+            except KeyError:
                 content = Content(block_cell_name, load=blob)
                 processor_changes.upsert(block_cell_name, content)
             else:
-                content.set_blob(blob)
+                content = resource.content
+                if content is None or blob != content.load:
+                    content = Content(block_cell_name, load=blob)
+                    processor_changes.upsert(block_cell_name, content)
+                else:
+                    content.set_blob(blob)
 
-        resource = Resource(cell, content)
-        block_holder.add_resource(resource)
+            resource = Resource(cell, content)
+            block_holder.add_resource(resource)
 
-    for cell_name, resource in block_holder.resources.items():
-        if cell_name not in types_blobs:
-            if resource.content is not None:
-                processor_changes.delete(resource.name)
-            block_holder.delete_resource(cell_name)
-    hive_holder.hive.update(processor_changes)
-
-
-def checkin_files(hive_holder, settings, files, biiout):
-    '''
-    Params:
-        hive_holder: HiveHolder
-        files: dict{BlockCellName: Item (str or bytes loaded from file)}
-        biiout: biiout
-    Returns: ProcessorChanges
-    '''
-    logger.debug("----------- checkin  ---------------")
-    hive = hive_holder.hive
-    hive.settings = settings
-
-    processor_changes = ProcessorChanges()
-    if files is None:
-        return processor_changes
-
-    block_files = {}
-    for block_cell_name, filecontent in files.iteritems():
-        block_files.setdefault(block_cell_name.block_name,
-                               {})[block_cell_name.cell_name] = filecontent
-
-    for block_name, files in block_files.iteritems():
-        checkin_block_files(hive_holder, block_name, files, processor_changes, biiout)
-
-    for block_holder in hive_holder.block_holders:
-        if block_holder.block_name not in block_files:
-            processor_changes.deleted.update(block_holder.block_cell_names)
-            hive_holder.add_holder(BlockHolder(block_holder.block_name, []))
-
-    hive_holder.delete_empty_blocks()
-    hive.update(processor_changes)
-
-    # Raises if max is overtaken
-    changevalidator.check_hive_num_cells(hive)
-    return processor_changes
+        for cell_name, resource in block_holder.resources.items():
+            if cell_name not in types_blobs:
+                if resource.content is not None:
+                    processor_changes.delete(resource.name)
+                block_holder.delete_resource(cell_name)
+        self.hive_holder.hive.update(processor_changes)
 
 
-def obtain_types_blobs(files):
+def obtain_types_blobs(files, normalize):
     """files: dict{BlockCellName: Item (str or bytes loaded from file)}
+    normalize: Boolean, normalize Blobs (crlf) or not
     return: {BlockCellName: (BiiType, Blob)}
     """
     tree = {}
@@ -107,15 +121,16 @@ def obtain_types_blobs(files):
         base_tree[tokens[-1]] = block_cell_name, filecontent
 
     result = {}
-    apply_types(tree, TypeFilter(), result)
+    apply_types(tree, TypeFilter(), result, normalize)
     return result
 
 
-def apply_types(base_tree, current_types, result):
+def apply_types(base_tree, current_types, result, normalize):
     '''
     Params:
         base_tree: {block_name: (CellName, content_str)}
         current_types: TypeFilter
+        normalize: Boolean, normalize Blobs (crlf) or not
         result: dict
     '''
     types_resource = base_tree.get('types.bii')
@@ -125,11 +140,11 @@ def apply_types(base_tree, current_types, result):
     for value in base_tree.itervalues():
         if isinstance(value, dict):
             base_tree = value
-            apply_types(base_tree, current_types, result)
+            apply_types(base_tree, current_types, result, normalize)
         else:
             block_cell_name, filecontent = value
             bii_type = _get_type_cell(filecontent, current_types, block_cell_name)
-            blob = Blob(filecontent, is_binary=bii_type.is_binary())
+            blob = Blob(filecontent, is_binary=bii_type.is_binary(), normalize=normalize)
             result[block_cell_name] = bii_type, blob
 
 

--- a/model/blob.py
+++ b/model/blob.py
@@ -10,23 +10,25 @@ class Blob(object):
     """ Object to hold content bytes, and manage lazy compression
     """
 
-    def __init__(self, blob=None, is_binary=False):
+    def __init__(self, blob=None, is_binary=False, normalize=True):
         '''
         param blob: str object containing bytes, used as byte array or text string
         param is_binary: if True, nothing will be done, normalization to LF otherwise
         '''
+
         self._compressed_bin = None  # The load, but compressed
         self._sys_text = None  # Transient, the load text as system CRLF requires
         self._sha = None  # shas are also lazily computed
         self._is_binary = is_binary
         # The real load of the blob
-        if is_binary:
+        if is_binary or not normalize:
             self._binary = blob
         elif blob is not None:
             assert isinstance(blob, basestring)
             self._binary = blob.replace(b'\r\n', '\n').replace(b'\r', '\n')
         else:
             self._binary = None
+
         self._size = None
         self.serialize_bytes = True
 
@@ -156,5 +158,6 @@ class Blob(object):
             c._size = data.get(Blob.SERIAL_SIZE_KEY)
         except KeyError:
             pass
+
         c._sha = SHA.deserialize(data[Blob.SERIAL_SHA_KEY])
         return c

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -12,13 +12,24 @@ from biicode.common.settings.cmakesettings import CMakeSettings
 
 
 class UserSettings(dict):
+
+    def __init__(self, *args, **kwargs):
+        self["autocrlf"] = True  # Default, overrided if exists in args dict
+        dict.__init__(self, *args, **kwargs)
+
     def serialize(self):
         return dict(self)
 
     @staticmethod
     def deserialize(data):
         deserializer = DictDeserializer(str, str)
-        return UserSettings(deserializer.deserialize(data))
+        tmp = deserializer.deserialize(data)
+        for key, value in tmp.iteritems():
+            convert = {"false": False, "False": False,
+                       "True": True, "true": True}
+            value = convert.get(value, value)
+            tmp[key] = value
+        return UserSettings(tmp)
 
 
 class Settings(object):

--- a/test/edition/checkin_test.py
+++ b/test/edition/checkin_test.py
@@ -1,16 +1,61 @@
 import unittest
-from biicode.common.edition.checkin import obtain_types_blobs
+from biicode.common.edition.checkin import obtain_types_blobs, CheckinManager
 from biicode.common.model.bii_type import CPP
 from biicode.common.model.blob import Blob
+import os
+from biicode.common.settings.settings import Settings
+from mock import Mock
+from biicode.common.model.brl.block_cell_name import BlockCellName
+from biicode.common.edition.hive_holder import HiveHolder
+from biicode.common.edition.hive import Hive
 
 
 class ChekinTest(unittest.TestCase):
 
     def obtain_types_blobs_test(self):
-        files = {'afile1.c': 'Hello',
-                 'bii/file2.c': 'Bye'}
-        result = obtain_types_blobs(files)
-        self.assertEqual({'afile1.c': (CPP, Blob('Hello')),
-                          'bii/file2.c': (CPP, Blob('Bye'))},
+        files = {'afile1.c': 'Hello\r\n',
+                 'bii/file2.c': 'Bye\n'}
+        normalize = True
+        result = obtain_types_blobs(files, normalize)
+        self.assertEqual({'afile1.c': (CPP, Blob('Hello%s' % os.linesep, normalize=normalize)),
+                          'bii/file2.c': (CPP, Blob('Bye%s' % os.linesep, normalize=normalize))},
                          result)
 
+        # Now not normalize
+        normalize = False
+        result = obtain_types_blobs(files, normalize)
+        self.assertEqual(result["afile1.c"][1].bytes, 'Hello\r\n')
+        self.assertEqual(result["bii/file2.c"][1].bytes, 'Bye\n')
+
+    def checkin_manager_test(self):
+        '''
+        Tests CheckinManager and normalizing.
+        Instance a ChekinManager and checkin files, first normalizing and
+        then without normalizing
+        '''
+        settings = Mock(Settings())
+        settings.user = {"autocrlf": True}
+        hive_holder = HiveHolder(Hive(), {}, {})
+        biiout = Mock()
+        manager = CheckinManager(hive_holder, settings, biiout)
+
+        files = {BlockCellName('user/block/file1.c'): 'Hello\r\n',
+                 BlockCellName('user/block2/file2.c'): 'Bye\n'}
+
+        manager.checkin_files(files)
+
+        file1_content = hive_holder.resources["user/block/file1.c"].content.load.bytes
+        self.assertEqual(file1_content, 'Hello%s' % os.linesep)
+
+        file2_content = hive_holder.resources["user/block2/file2.c"].content.load.bytes
+        self.assertEqual(file2_content, 'Bye%s' % os.linesep)
+
+        # Now not normalize
+        settings.user = {"autocrlf": False}
+        manager.checkin_files(files)
+
+        file1_content = hive_holder.resources["user/block/file1.c"].content.load.bytes
+        self.assertEqual(file1_content, 'Hello\r\n')
+
+        file2_content = hive_holder.resources["user/block2/file2.c"].content.load.bytes
+        self.assertEqual(file2_content, 'Bye\n')

--- a/test/model_creator.py
+++ b/test/model_creator.py
@@ -36,7 +36,8 @@ def make_content(brl, lang=BiiType(UNKNOWN), read_file=True):
 
 
 def make_too_big_content(brl, lang=BiiType(UNKNOWN)):
-    blob = Blob(path=testfileutils.file_path("limits/largefile.txt"), is_binary=True)
+    text = testfileutils.read("limits/largefile.txt")
+    blob = Blob(text, is_binary=True)
     parser = parser_factory(lang, brl.cell_name)
     return Content(brl, blob, parser)
 

--- a/test/settings/settings_serialization_test.py
+++ b/test/settings/settings_serialization_test.py
@@ -23,7 +23,7 @@ defines:
     def test_user_defined_settings(self):
         raw_settings = '''cmake: {generator: Visual}
 os: {arch: 64bit, family: MacOS, version: 10.9.1}
-user: {my_definition: hola, my_other_definition: adios}
+user: {autocrlf: true, my_definition: hola, my_other_definition: adios}
 '''
         settings = Settings.loads(raw_settings)
         self.assertTrue(hasattr(settings, 'user'))


### PR DESCRIPTION
CheckinManager receives common parameters (hive_holder, biiout and now settings)  for handle principal methods: checkin_block_files and checkin_files

Blob objects are created with a new parameter, normalize, with default to True.

User settings has new parameter, autocrlf, True by default, corresponding to "normalize" parameter in blobs.

